### PR TITLE
feat: Refactor CacheService to use TagService's getHotTags method

### DIFF
--- a/app/Helper/CacheService.php
+++ b/app/Helper/CacheService.php
@@ -43,8 +43,7 @@ class CacheService
         }
         $seconds = 60 * 180; // 3 hours
         return Cache::remember('hot_tags', $seconds, function() {
-            $tags = (new TagService)->get();
-            return $tags;
+            return app(TagService::class)->getHotTags();
         });
     }
 
@@ -77,6 +76,7 @@ class CacheService
 
         return $cache;
     }
+
 
     static public function rememberPostUpdatedTimestamp($fresh = false)
     {

--- a/app/Http/Controllers/Api/TagController.php
+++ b/app/Http/Controllers/Api/TagController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Enums\PostAccessPolicy;
+use App\Helper\CacheService;
 use App\Http\Controllers\Controller;
 use App\Models\Tag;
 use Illuminate\Http\Request;
@@ -20,7 +21,7 @@ class TagController extends Controller
 
     public function index(Request $request)
     {
-        $tags = $this->tagService->getHotTags();
+        $tags = CacheService::rememberHotTags();
 
         return response()->json($tags);
     }

--- a/app/Services/TagService.php
+++ b/app/Services/TagService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\PostAccessPolicy;
 use App\Helper\CacheService;
+use App\Repositories\Filters\PostFilter;
 use DB;
 use App\Models\Tag;
 
@@ -32,13 +33,21 @@ class TagService
     public function getHotTags(int $limit = 10)
     {
         // get the hot psots
-        $posts = CacheService::rememberPosts(request(), 'hot');
+        $posts = app(PostService::class)->getList([
+            PostFilter::PUBLIC => true,
+            PostFilter::ELEMENTS_COUNT_GTE => config('setting.post_min_element_count'),
+        ],[
+            'sort_by' => 'hot',
+            'sort_dir' => 'week',
+        ], [
+            'per_page' => config('setting.home_post_per_page')
+        ]);
 
         $tags = [];
         foreach ($posts as $post) {
-            foreach ($post['tags'] as $tag) {
-                if(!in_array($tag, $tags)) {
-                    $tags[] = $tag;
+            foreach ($post->tags as $tag) {
+                if(!in_array($tag->name, $tags)) {
+                    $tags[] = $tag->name;
                 }
             }
         }


### PR DESCRIPTION
Refactor the CacheService class to use the getHotTags method from the TagService class. This change improves code readability and reduces duplication.