### PR TITLE
fix: Updated argument name from 'posts.id' to 'post_id' in PostTrendS…

### DIFF
--- a/app/ScheduleExecutor/PostTrendScheduleExecutor.php
+++ b/app/ScheduleExecutor/PostTrendScheduleExecutor.php
@@ -100,6 +100,6 @@ class PostTrendScheduleExecutor
                     'position' => $count,
                     'start_date' => $startDate
                 ]);
-            }, 1000, 'posts.id');
+            }, 1000, 'post_id');
     }
 }


### PR DESCRIPTION
…cheduleExecutor